### PR TITLE
Fix encryption key requirement in KeycloakClientBundle

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -28,6 +28,12 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('encryption_algorithm')->defaultNull()->end()
                         ->scalarNode('encryption_key')->defaultNull()->end()
                         ->scalarNode('encryption_key_path')->defaultNull()->end()
+                        ->validate()
+                            ->ifTrue(function ($v) {
+                                return empty($v['encryption_key']) && empty($v['encryption_key_path']);
+                            })
+                            ->thenInvalid('At least one of "encryption_key" or "encryption_key_path" must be provided.')
+                        ->end()
                         ->scalarNode('version')->defaultNull()->end()
                     ->end()
                 ->end()

--- a/src/Provider/KeycloakClient.php
+++ b/src/Provider/KeycloakClient.php
@@ -44,12 +44,11 @@ class KeycloakClient implements IamClientInterface
 
         if ('RS256' === $this->encryption_algorithm) {
             if ('' === $this->encryption_key && '' === $this->encryption_key_path) {
-                throw new \RuntimeException('encryption_key is empty');
+                throw new \RuntimeException('Either encryption_key or encryption_key_path must be provided.');
             }
             if ('' !== $this->encryption_key) {
                 $this->keycloakProvider->setEncryptionKey($this->encryption_key);
-            }
-            if ('' !== $this->encryption_key_path) {
+            } elseif ('' !== $this->encryption_key_path) {
                 $this->keycloakProvider->setEncryptionKeyPath($this->encryption_key_path);
             }
         }


### PR DESCRIPTION
Fixes #20

Update the encryption key configuration to make the path optional if the key is provided.

* **Configuration Validation**
  - Add validation in `src/DependencyInjection/Configuration.php` to ensure that at least one of `encryption_key` or `encryption_key_path` is provided.

* **KeycloakClient Constructor**
  - Update the constructor in `src/Provider/KeycloakClient.php` to throw an exception only if both `encryption_key` and `encryption_key_path` are empty.
  - Modify the logic to set the encryption key using either `encryption_key` or `encryption_key_path` if they are provided.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mainick/KeycloakClientBundle/issues/20?shareId=6969034e-6c15-4bd4-af4d-4fc4dc086c33).