### PR TITLE
Fixed use case to refresh token if access token is null and added AJAX request handling.

### DIFF
--- a/src/Security/EntryPoint/KeycloakAuthenticationEntryPoint.php
+++ b/src/Security/EntryPoint/KeycloakAuthenticationEntryPoint.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Mainick\KeycloakClientBundle\Security\EntryPoint;
 
 use Mainick\KeycloakClientBundle\DTO\KeycloakAuthorizationCodeEnum;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -15,15 +17,39 @@ use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface
 final readonly class KeycloakAuthenticationEntryPoint implements AuthenticationEntryPointInterface
 {
     public function __construct(
-        private UrlGeneratorInterface $urlGenerator
+        private UrlGeneratorInterface $urlGenerator,
+        private ?LoggerInterface $keycloakClientLogger = null,
     ) {
     }
 
     public function start(Request $request, ?AuthenticationException $authException = null): Response
     {
+        // Handling AJAX requests
+        if ($request->isXmlHttpRequest()) {
+            return new JsonResponse(
+                [
+                    'code' => Response::HTTP_UNAUTHORIZED,
+                    'message' => 'Authentication Required',
+                    'login_url' => $this->urlGenerator->generate('mainick_keycloak_security_auth_connect'),
+                ],
+                Response::HTTP_UNAUTHORIZED
+            );
+        }
+
         if ($request->hasSession()) {
             $request->getSession()->set(KeycloakAuthorizationCodeEnum::LOGIN_REFERRER, $request->getUri());
+
+            $request->getSession()->getBag('flashes')->add(
+                'info',
+                'Please log in to access this page',
+            );
         }
+
+        $this->keycloakClientLogger?->info('KeycloakAuthenticationEntryPoint::start', [
+            'path' => $request->getPathInfo(),
+            'error' => $authException?->getMessage(),
+            'loginReferrer' => $request->getUri(),
+        ]);
 
         return new RedirectResponse(
             $this->urlGenerator->generate('mainick_keycloak_security_auth_connect'),


### PR DESCRIPTION
I release a fix to handle the use case you indicated, throwing the `AuthenticationException` exception.
Also, I added AJAX request handling and logging if it can be useful for debugging.

close #30