### PR TITLE
Allow symfony 6.4 and fixing condition for valid "0" responses

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "stevenmaguire/oauth2-keycloak": "^5.1",
     "symfony/routing": "^6.4|^7.2",
     "symfony/security-bundle": "^6.4|^7.2",
-    "symfony/http-kernel": "^^6.4|7.2",
+    "symfony/http-kernel": "^6.4|7.2",
     "symfony/framework-bundle": "^6.4|^7.2",
     "symfony/serializer-pack": "^1.3"
   },

--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
   "require": {
     "php": ">=8.2",
     "stevenmaguire/oauth2-keycloak": "^5.1",
-    "symfony/routing": "^7.2",
-    "symfony/security-bundle": "^7.2",
-    "symfony/http-kernel": "^7.2",
-    "symfony/framework-bundle": "^7.2",
+    "symfony/routing": "^6.4|^7.2",
+    "symfony/security-bundle": "^6.4|^7.2",
+    "symfony/http-kernel": "^^6.4|7.2",
+    "symfony/framework-bundle": "^6.4|^7.2",
     "symfony/serializer-pack": "^1.3"
   },
   "require-dev": {

--- a/src/Service/Service.php
+++ b/src/Service/Service.php
@@ -51,7 +51,7 @@ abstract class Service
                 'response' => $content,
             ]);
 
-            if (empty($content)) {
+            if ($content === '' || $content === null) {
                 throw new \UnexpectedValueException('Empty response');
             }
 


### PR DESCRIPTION
1) i found a bug for count api calls
2) symfony 6.4 should also work, we have some projects that are not currently at symfony 7.x