### PR TITLE
Add support for user logout endpoint

### DIFF
--- a/src/Service/UsersService.php
+++ b/src/Service/UsersService.php
@@ -54,6 +54,11 @@ final class UsersService extends Service
         return $this->executeCommand(HttpMethodEnum::DELETE, 'admin/realms/'.$realm.'/users/'.$userId);
     }
 
+    public function logout(string $realm, string $userId): bool
+    {
+        return $this->executeCommand(HttpMethodEnum::POST, 'admin/realms/'.$realm.'/users/'.$userId.'/logout');
+    }
+
     /**
      * @return UserSessionCollection<UserSessionRepresentation>|null
      */

--- a/tests/Service/UsersServiceTest.php
+++ b/tests/Service/UsersServiceTest.php
@@ -345,6 +345,37 @@ class UsersServiceTest extends TestCase
         $this->assertTrue($result);
     }
 
+    public function testLogout(): void
+    {
+        // given
+        $realm = 'test-realm';
+        $userId = 'user1';
+        $responseBody = '';
+        $stream = $this->createMock(StreamInterface::class);
+        $stream->method('getContents')->willReturn($responseBody);
+
+        $response = m::mock(ResponseInterface::class);
+        $response->shouldReceive('getStatusCode')->andReturn(204);
+        $response->shouldReceive('getBody')->andReturn($stream);
+
+        $this->httpClient
+            ->shouldReceive('request')
+            ->with(
+                'POST',
+                'admin/realms/'.$realm.'/users/'.$userId.'/logout',
+                m::type('array')
+            )
+            ->andReturn($response);
+
+        $this->logger->shouldReceive('info')->once();
+
+        // when
+        $result = $this->usersService->logout($realm, $userId);
+
+        // then
+        $this->assertTrue($result);
+    }
+
     public function testSessions(): void
     {
         // given


### PR DESCRIPTION
Can be useful for exemple to call it before deleting a user.

<img width="1084" height="592" alt="image" src="https://github.com/user-attachments/assets/ab168a9b-61ac-4680-947e-71d98242d269" />
